### PR TITLE
Added a "use_joins" approach to the interpolation to help reduce memory usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ coverage.xml
 
 # Miscellaneous files
 notes.txt
+*.DS_Store

--- a/openet/core/__init__.py
+++ b/openet/core/__init__.py
@@ -3,4 +3,4 @@ from . import common
 from . import interp
 from . import utils
 
-__version__ = "0.0.10"
+__version__ = "0.0.11"

--- a/openet/core/tests/test_interp.py
+++ b/openet/core/tests/test_interp.py
@@ -15,6 +15,36 @@ def test_ee_init():
     assert ee.Number(1).getInfo() == 1
 
 
+def tgt_image(tgt_value, tgt_time):
+    # tgt_images = []
+    # for tgt_value, tgt_time in zip(tgt_values, tgt_timess):
+    return ee.Image.constant(tgt_value).rename(['tgt'])\
+        .set({'system:time_start': tgt_time,
+              'system:index': datetime.datetime.utcfromtimestamp(
+                  tgt_time / 1000.0).strftime('%Y%m%d')})
+
+def src_images(src_values, src_times):
+    """Build constant source images from values and times"""
+    src_images = []
+    for src, time in zip(src_values, src_times):
+        date_0utc = utils.date_0utc(ee.Date(time))
+        time_0utc = date_0utc.millis()
+        if src is not None:
+            image = ee.Image.constant([src, time_0utc]).double() \
+                .rename(['src', 'time']) \
+                .set({
+                    'system:index': ee.Date(time).format('yyyyMMdd'),
+                    'system:time_start': time})
+        else:
+            image = ee.Image.constant([1, time_0utc]).double().updateMask(0) \
+                .rename(['src', 'time']) \
+                .set({
+                    'system:index': ee.Date(time).format('yyyyMMdd'),
+                    'system:time_start': time})
+        src_images.append(image)
+    return src_images
+
+
 @pytest.mark.parametrize(
     # GRIDMET start times are 7 UTC
     #   1439532000000 - 2015-08-14
@@ -34,16 +64,14 @@ def test_ee_init():
     "tgt_value, tgt_time, src_values, src_times, expected",
     [
         # Test normal interpolation between two images
+        # CGM - I'm not sure why this first test fails
         # [10, 1439618400000, [0.0, 1.6], [1439660268614, 1441042674222], 0.0],
         [10, 1439704800000, [0.0, 1.6], [1439660268614, 1441042674222], 0.1],
         [10, 1440309600000, [0.0, 1.6], [1439660268614, 1441042674222], 0.8],
-        # This fails?
         [10, 1441000800000, [0.0, 1.6], [1439660268614, 1441042674222], 1.6],
-
         # Test if one side of the range is totally nodata
         [10, 1439704800000, [0.0, None], [1439660268614, 1441042674222], 0.0],
         [10, 1439704800000, [None, 1.6], [1439660268614, 1441042674222], 1.6],
-
         # Test with multiple dates
         [10, 1439704800000, [0.0, 1.6, 3.2, 4.8],
          [1438277862725, 1439660268614, 1441042674222, 1442425082323], 1.7],
@@ -51,7 +79,6 @@ def test_ee_init():
          [1438277862725, 1439660268614, 1441042674222, 1442425082323], 1.7],
         [10, 1439704800000, [0.0, 1.6, None, 4.8],
          [1438277862725, 1439660268614, 1441042674222, 1442425082323], 1.7],
-
         # Test with real data
         [
             4.8153934,
@@ -68,32 +95,44 @@ def test_ee_init():
 def test_daily_collection(tgt_value, tgt_time, src_values, src_times,
                           expected, tol=0.01):
     """Test the daily method for collections of constant images"""
-    tgt_coll = ee.ImageCollection([
-        ee.Image.constant(tgt_value).rename(['tgt'])\
-            .set({'system:time_start': tgt_time})])
-
-    src_images = []
-    for src, time in zip(src_values, src_times):
-        date_0utc = utils.date_0utc(ee.Date(time))
-        time_0utc = date_0utc.millis()
-        if src is not None:
-            image = ee.Image.constant([src, time_0utc]).double() \
-                .rename(['src', 'time']) \
-                .set({
-                    'system:index': ee.Date(time).format('yyyyMMdd'),
-                    'system:time_start': time})
-        else:
-            image = ee.Image.constant([1, time_0utc]).double().updateMask(0) \
-                .rename(['src', 'time']) \
-                .set({
-                    'system:index': ee.Date(time).format('yyyyMMdd'),
-                    'system:time_start': time})
-        src_images.append(image)
-    src_coll = ee.ImageCollection.fromImages(src_images)
-
+    tgt_coll = ee.ImageCollection([tgt_image(tgt_value, tgt_time)])
+    src_coll = ee.ImageCollection.fromImages(src_images(src_values, src_times))
     output_coll = interp.daily(
-        tgt_coll, src_coll, interp_days=32, interp_method='linear')
+        tgt_coll, src_coll, interp_days=32, interp_method='linear',
+        use_joins=False)
+    output = utils.constant_image_value(ee.Image(output_coll.first()))
+    assert abs(output['src'] - expected) <= tol
+    assert abs(output['tgt'] - tgt_value) <= tol
 
+
+@pytest.mark.parametrize(
+    "tgt_value, tgt_time, src_values, src_times, expected",
+    [
+        # CGM - I'm not sure why this first test fails
+        # [10, 1439618400000, [0.0, 1.6], [1439660268614, 1441042674222], 0.0],
+        [10, 1439704800000, [0.0, 1.6], [1439660268614, 1441042674222], 0.1],
+        [10, 1440309600000, [0.0, 1.6], [1439660268614, 1441042674222], 0.8],
+        [10, 1441000800000, [0.0, 1.6], [1439660268614, 1441042674222], 1.6],
+        # Test if one side of the range is totally nodata
+        [10, 1439704800000, [0.0, None], [1439660268614, 1441042674222], 0.0],
+        [10, 1439704800000, [None, 1.6], [1439660268614, 1441042674222], 1.6],
+        # Test with multiple dates
+        [10, 1439704800000, [0.0, 1.6, 3.2, 4.8],
+         [1438277862725, 1439660268614, 1441042674222, 1442425082323], 1.7],
+        [10, 1439704800000, [0.0, None, 3.2, 4.8],
+         [1438277862725, 1439660268614, 1441042674222, 1442425082323], 1.7],
+        [10, 1439704800000, [0.0, 1.6, None, 4.8],
+         [1438277862725, 1439660268614, 1441042674222, 1442425082323], 1.7],
+    ]
+)
+def test_daily_use_joins_true(tgt_value, tgt_time, src_values, src_times,
+                              expected, tol=0.01):
+    """Test that output with use_joins=True is the same as use_joins=False"""
+    tgt_coll = ee.ImageCollection([tgt_image(tgt_value, tgt_time)])
+    src_coll = ee.ImageCollection.fromImages(src_images(src_values, src_times))
+    output_coll = interp.daily(
+        tgt_coll, src_coll, interp_days=32, interp_method='linear',
+        use_joins=True)
     output = utils.constant_image_value(ee.Image(output_coll.first()))
     assert abs(output['src'] - expected) <= tol
     assert abs(output['tgt'] - tgt_value) <= tol
@@ -102,7 +141,11 @@ def test_daily_collection(tgt_value, tgt_time, src_values, src_times,
 @pytest.mark.parametrize(
     "interp_days, tgt_value, tgt_time, src_values, src_times, expected",
     [
-        # Commented out half the tests that seemed redundant
+        # Return 1st value if 2nd value is outside interp_days window
+        # Return 2nd value if 1st value is outside interp_days window
+        # Return nodata if 1st and 2nd value are both outside window
+        # Return interpolated value if 1st and 2nd value are both inside window
+        # First try interp_days that is much smaller than time step (4 days)
         [4, 10, 1439618400000, [0.0, 1.6], [1439660268614, 1441042674222], 0.0],
         [4, 10, 1439704800000, [0.0, 1.6], [1439660268614, 1441042674222], 0.0],
         [4, 10, 1439791200000, [0.0, 1.6], [1439660268614, 1441042674222], 0.0],
@@ -120,6 +163,7 @@ def test_daily_collection(tgt_value, tgt_time, src_values, src_times,
         [4, 10, 1440828000000, [0.0, 1.6], [1439660268614, 1441042674222], 1.6],
         [4, 10, 1440914400000, [0.0, 1.6], [1439660268614, 1441042674222], 1.6],
         [4, 10, 1441000800000, [0.0, 1.6], [1439660268614, 1441042674222], 1.6],
+        # Same as above but with a larger interp_days value
         [10, 10, 1439618400000, [0.0, 1.6], [1439660268614, 1441042674222], 0.0],
         [10, 10, 1439704800000, [0.0, 1.6], [1439660268614, 1441042674222], 0.0],
         [10, 10, 1439791200000, [0.0, 1.6], [1439660268614, 1441042674222], 0.0],
@@ -139,25 +183,19 @@ def test_daily_collection(tgt_value, tgt_time, src_values, src_times,
         [10, 10, 1441000800000, [0.0, 1.6], [1439660268614, 1441042674222], 1.6],
     ]
 )
-def test_daily_interp_days(interp_days, tgt_value, tgt_time, src_values,
-                           src_times, expected, tol=0.01):
-    """Test the daily method for small interp_days values"""
-    tgt_coll = ee.ImageCollection([
-        ee.Image.constant(tgt_value).rename(['tgt'])\
-            .set({'system:time_start': tgt_time,
-                  'system:index': datetime.datetime.utcfromtimestamp(
-                      tgt_time / 1000.0).strftime('%Y-%m-%d')})])
-    src_coll = ee.ImageCollection([
-        ee.Image.constant([value, utils.date_0utc(ee.Date(time)).millis()])\
-            .double().rename(['src', 'time'])\
-            .set({'system:time_start': time,
-                  'system:index': datetime.datetime.utcfromtimestamp(
-                      time / 1000.0).strftime('%Y-%m-%d')})
-        for time, value in zip(src_times, src_values)])
+def test_daily_small_interp_days(interp_days, tgt_value, tgt_time, src_values,
+                                 src_times, expected, tol=0.01):
+    """Test the daily method for small interp_days values
 
+    This is mainly an issue when the number of interp_days is less than the
+    timestep of the source images but can also be an issue when there are lots
+    of images missing due to clouds.
+    """
+    tgt_coll = ee.ImageCollection([tgt_image(tgt_value, tgt_time)])
+    src_coll = ee.ImageCollection.fromImages(src_images(src_values, src_times))
     output_coll = ee.ImageCollection(interp.daily(
-        tgt_coll, src_coll, interp_days=interp_days, interp_method='linear'))
-
+        tgt_coll, src_coll, interp_days=interp_days, interp_method='linear',
+        use_joins=False))
     output = utils.constant_image_value(ee.Image(output_coll.first()))
     if expected is None:
         assert output['src'] is None
@@ -168,8 +206,39 @@ def test_daily_interp_days(interp_days, tgt_value, tgt_time, src_values,
 
 
 @pytest.mark.parametrize(
-    #
-    "etf_values, time_values, expected",
+    "interp_days, tgt_value, tgt_time, src_values, src_times, expected",
+    [
+        # [4, 10, 1439618400000, [0.0, 1.6], [1439660268614, 1441042674222], 0.0],
+        [4, 10, 1439704800000, [0.0, 1.6], [1439660268614, 1441042674222], 0.0],
+
+    ]
+)
+def test_daily_interp_days_use_joins(interp_days, tgt_value, tgt_time, src_values,
+                                     src_times, expected, tol=0.01):
+    """Test the daily method for small interp_days values"""
+    tgt_coll = ee.ImageCollection([tgt_image(tgt_value, tgt_time)])
+    src_coll = ee.ImageCollection.fromImages(src_images(src_values, src_times))
+
+    # pprint.pprint(tgt_coll.getInfo())
+    # pprint.pprint(src_coll.getInfo())
+
+    output_coll = ee.ImageCollection(interp.daily(
+        tgt_coll, src_coll, interp_days=interp_days, interp_method='linear',
+        use_joins=True))
+    pprint.pprint(src_coll.getInfo())
+
+    # output = utils.constant_image_value(ee.Image(output_coll.first()))
+    # if expected is None:
+    #     assert output['src'] is None
+    #     assert abs(output['tgt'] - tgt_value) <= tol
+    # else:
+    #     assert abs(output['src'] - expected) <= tol
+    #     assert abs(output['tgt'] - tgt_value) <= tol
+    assert False
+
+
+@pytest.mark.parametrize(
+    "src_values, time_values, expected",
     [
         # Test compositing/mosaicing between two images on the same day
         #     and in the same path, but different rows.
@@ -182,29 +251,13 @@ def test_daily_interp_days(interp_days, tgt_value, tgt_time, src_values,
         [[10.0, None], [1439660244726, 1439660268614], 10.0],
     ]
 )
-def test_aggregate_daily_values_single_band(etf_values, time_values, expected,
+def test_aggregate_daily_values_single_band(src_values, time_values, expected,
                                             tol=0.01):
     """Test daily aggregation function for single-band constant images"""
-    image_list = []
-    time_list = []
-    for etf, time in zip(etf_values, time_values):
-        date_0utc = utils.date_0utc(ee.Date(time))
-        time_0utc = date_0utc.millis()
-        if etf is not None:
-            image = ee.Image.constant([etf, time_0utc]).double()\
-                .rename(['etf', 'time'])\
-                .set({
-                    'system:index': ee.Date(time).format('yyyyMMdd'),
-                    'system:time_start': time})
-        else:
-            image = ee.Image.constant(1).double().updateMask(0)\
-                .addBands(ee.Image.constant(time_0utc).double())\
-                .rename(['etf', 'time'])\
-                .set({
-                    'system:index': ee.Date(time).format('yyyyMMdd'),
-                    'system:time_start': time})
-        image_list.append(image)
-        time_list.append(time_0utc.getInfo())
+    image_list = src_images(src_values, time_values)
+    time_list = [
+        utils.date_0utc(ee.Date(time)).millis().getInfo()
+        for time in time_values]
 
     # Dates can be ISO Date string or milliseconds since epoch
     # Use the date strings to get 0 UTC dates and better match model calls
@@ -213,13 +266,13 @@ def test_aggregate_daily_values_single_band(etf_values, time_values, expected,
     # start_date = min(time_values)
     # end_date = max(time_values)
 
-    etf_coll = interp.aggregate_daily(
+    src_coll = interp.aggregate_daily(
         ee.ImageCollection.fromImages(image_list),
         start_date, end_date, agg_type='mean')
-    etf_image = ee.Image(etf_coll.first())
+    src_image = ee.Image(src_coll.first())
 
-    output = utils.constant_image_value(etf_image)
-    assert abs(output['etf'] - expected) <= tol
+    output = utils.constant_image_value(src_image)
+    assert abs(output['src'] - expected) <= tol
     assert output['time'] == 0.5 * sum(time_list)
 
 


### PR DESCRIPTION
The joins approach does reduce memory usage and allow for interpolations that may fail using the standard approach, but it will fail for some small study areas and/or small interpolation window sizes that have no images to interpolate from.